### PR TITLE
Fix Arm issue for rancher

### DIFF
--- a/Dockerfile.build.alpine
+++ b/Dockerfile.build.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.10.2-alpine
+FROM golang:1.13.10-alpine
 
 RUN apk add --no-cache make git
 RUN mkdir -p /go/src/github.com/kelseyhightower/confd && \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL:=/bin/bash
 .PHONY: build install clean test integration dep release
 VERSION=`egrep -o '[0-9]+\.[0-9a-z.\-]+' version.go`
 GIT_SHA=`git rev-parse --short HEAD || echo`
@@ -37,4 +38,3 @@ release:
 		docker run -it --rm -v ${PWD}:/app -e "GOOS=$$platform" -e "GOARCH=amd64" -e "CGO_ENABLED=0" confd_builder go build -ldflags="-s -w -X main.GitSHA=${GIT_SHA}" -o bin/confd-${VERSION}-$$platform-amd64$$extension; \
 	done
 	@docker run -it --rm -v ${PWD}:/app -e "GOOS=linux" -e "GOARCH=arm64" -e "CGO_ENABLED=0" confd_builder go build -ldflags="-s -w -X main.GitSHA=${GIT_SHA}" -o bin/confd-${VERSION}-linux-arm64;
-	@upx bin/confd-${VERSION}-*

--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@
   [vault](https://vaultproject.io), [zookeeper](https://zookeeper.apache.org), [aws ssm parameter store](https://aws.amazon.com/ec2/systems-manager/) or env vars and processing [template resources](docs/template-resources.md).
 * reloading applications to pick up new config file changes
 
+## Rancher Release Instructions
+
+An x86 host like Ubuntu 18.04 is recommended, the Docker should be installed on it.
+
+```
+$ apt install make
+
+$ git checkout -t origin/release/v0.16
+$ make release
+
+# You should now have confd in your bin directory:
+$ ls bin/
+```
+
+To upload the artifacts to the Github release, you can use [hub](https://github.com/github/hub).
+
+After making a release on the Github UI, you can try this script:
+
+```
+$ ./upload.sh <release-tag>
+```
+
 ## Community
 
 * IRC: `#confd` on Freenode

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TAG=$1
+
+pushd bin/
+for artifact in `ls .`; do
+    hub release edit -m ${TAG} -a ${artifact} ${TAG}
+done
+popd

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const Version = "0.16.0"
+const Version = "0.16.0-rancher"
 
 // We want to replace this variable at build time with "-ldflags -X main.GitSHA=xxx", where const is not supported.
 var GitSHA = ""


### PR DESCRIPTION
We tested Rancher on the Arm server (HUAWEI) of a Chinese customer and found that there was a problem with our rke-tools and its built-in confd could not run. However, this problem cannot be reproduced on the AWS Arm instance.

We need to release a new version of confd and make a PR to rke-tools to address this issue.