### PR TITLE
remove go setup from gh action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Dapper CI on PR and Merge
-run-name: Release ${{ github.ref_name }}
+run-name: CI on Merge to ${{ github.ref_name }}
 
 on:
   pull_request:
@@ -19,12 +19,7 @@ jobs:
         run: |
           apk -U add git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-            go-version-file: go.mod
       - name: build with Dapper
         run: dapper ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-            go-version-file: go.mod
       - name: build with Dapper
         run: dapper ci
         


### PR DESCRIPTION
the dapper container is conflicting with [the GH `go setup` action](https://github.com/rancher/confd/actions/runs/9228391618/job/25392321813). I believe the right path is to let the container run without trying to setup go separately. 